### PR TITLE
API For adding an objective to a plan

### DIFF
--- a/.run/one-plan.http
+++ b/.run/one-plan.http
@@ -25,6 +25,17 @@ Authorization: Bearer {{auth_token}}
   "planType": "PERSONAL_LEARNING"
 }
 
+### Create a plan with an objective ref
+POST {{base.url}}/person/123/plans
+content-type: application/json
+Authorization: Bearer {{auth_token}}
+
+{
+  "planType": "PERSONAL_LEARNING",
+  "objectives": ["{{objectiveReference}}"]
+}
+
+
 > {% client.global.set("planReference", response.body["reference"]); %}
 
 ### Get plan

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   runtimeOnly("org.flywaydb:flyway-core:10.8.1")
   runtimeOnly("org.flywaydb:flyway-database-postgresql:10.8.1")
   runtimeOnly("org.springframework.boot:spring-boot-starter-jdbc")
-  runtimeOnly("org.postgresql:postgresql:42.7.1")
+  runtimeOnly("org.postgresql:postgresql:42.7.2")
   runtimeOnly("org.postgresql:r2dbc-postgresql")
 
   testImplementation("org.testcontainers:postgresql:1.19.5")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/config/HmppsOnePlanApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/config/HmppsOnePlanApiExceptionHandler.kt
@@ -86,12 +86,13 @@ class HmppsOnePlanApiExceptionHandler(
       type == LocalDate::class.java -> "must be a date in format yyyy-MM-dd"
       type == Boolean::class.java -> "must be a boolean true|false"
       type.isEnum -> "must be one of [${type.enumConstants.joinToString { it.toString() }}]"
+      type == UUID::class.java -> "must be a valid UUID"
       else -> "is invalid"
     }
   }
 
   private fun variablePath(cause: MismatchedInputException) =
-    cause.path.joinToString(".") { it.fieldName }
+    cause.path.joinToString(".") { it.fieldName ?: "[${it.index}]" }
 
   @ExceptionHandler(WebExchangeBindException::class)
   fun handleBindValidationException(e: WebExchangeBindException): ResponseEntity<ErrorResponse> {
@@ -141,7 +142,7 @@ class HmppsOnePlanApiExceptionHandler(
 
   @ExceptionHandler(DuplicateKeyException::class)
   fun handleDuplicateKeyException(e: DuplicateKeyException): ResponseEntity<ErrorResponse> = ResponseEntity
-    .status(HttpStatus.UNPROCESSABLE_ENTITY)
+    .status(UNPROCESSABLE_ENTITY)
     .body(
       ErrorResponse(
         status = UNPROCESSABLE_ENTITY.value(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/CreateObjectiveRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/CreateObjectiveRequest.kt
@@ -15,7 +15,7 @@ data class CreateObjectiveRequest(
   val status: ObjectiveStatus,
   val note: String?,
   val outcome: String?,
-  @Schema(description = "Optional plan reference to add objective to", required = false)
+  @field:Schema(description = "Optional plan reference to add objective to")
   val planReference: UUID? = null,
 ) {
   fun buildEntity(crn: CaseReferenceNumber): ObjectiveEntity = ObjectiveEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveController.kt
@@ -120,7 +120,7 @@ class ObjectiveController(private val service: ObjectiveService) {
   )
   @GetMapping("/person/{crn}/plans/{planReference}/objectives")
   suspend fun getObjectives(
-    @PathVariable(value = "crn") @Crn crn: String,
+    @PathVariable(value = "crn") @Crn crn: CaseReferenceNumber,
     @PathVariable(value = "planReference") planReference: UUID,
   ): Flow<ObjectiveEntity> {
     return service.getObjectives(PlanKey(crn, planReference))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveRepository.kt
@@ -18,6 +18,16 @@ interface ObjectiveRepository : CoroutineCrudRepository<ObjectiveEntity, UUID> {
   )
   suspend fun getObjective(crn: CaseReferenceNumber, objectiveReference: UUID): ObjectiveEntity?
 
+  @Query(
+    """
+    select * from objective
+    where reference in (:objectiveReferences)
+    and crn = :crn
+    and is_deleted = false
+  """,
+  )
+  suspend fun getObjectives(crn: CaseReferenceNumber, objectiveReferences: Collection<UUID>): Flow<ObjectiveEntity>
+
   @Modifying
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveService.kt
@@ -26,7 +26,7 @@ class ObjectiveService(
     val savedObjective = entityTemplate.insert(objective).awaitSingle()
 
     if (request.planReference != null) {
-      val plan = planService.getByKey(PlanKey(crn.value, request.planReference))
+      val plan = planService.getByKey(PlanKey(crn, request.planReference))
       val link = PlanObjectiveLink(planId = plan.id, objectiveId = objective.id)
       entityTemplate.insert(link).awaitSingle()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveService.kt
@@ -31,14 +31,7 @@ class ObjectiveService(
       entityTemplate.insert(link).awaitSingle()
     }
 
-    createPlanLinkIfRequired(request, savedObjective)
     return savedObjective
-  }
-
-  private fun createPlanLinkIfRequired(request: CreateObjectiveRequest, savedObjective: ObjectiveEntity) {
-    if (request.planReference == null) {
-      return
-    }
   }
 
   suspend fun getObjective(objectiveKey: ObjectiveKey): ObjectiveEntity {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/AddObjectivesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/AddObjectivesRequest.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsoneplanapi.plan
 
+import jakarta.validation.constraints.NotEmpty
 import java.util.UUID
 
 data class AddObjectivesRequest(
+  @field:NotEmpty
   val objectives: List<UUID>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/AddObjectivesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/AddObjectivesRequest.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsoneplanapi.plan
+
+import java.util.UUID
+
+data class AddObjectivesRequest(
+  val objectives: List<UUID>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/CreatePlanRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/CreatePlanRequest.kt
@@ -1,5 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsoneplanapi.plan
 
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED
+import java.util.UUID
+
 data class CreatePlanRequest(
   val planType: PlanType,
+  @field:Schema(requiredMode = NOT_REQUIRED, description = "Optionally add these objectives to the created plan")
+  val objectives: Collection<UUID> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsoneplanapi.common.CaseReferenceNumber
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.common.CreateEntityResponse
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.common.Crn
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.config.ErrorResponse
@@ -48,7 +49,7 @@ class PlanController(private val planService: PlanService) {
   )
   @PostMapping("/person/{crn}/plans")
   suspend fun createPlan(
-    @PathVariable(value = "crn") @Crn crn: String,
+    @PathVariable(value = "crn") @Crn crn: CaseReferenceNumber,
     @RequestBody planRequest: CreatePlanRequest,
   ): CreateEntityResponse {
     val entity = planService.createPlan(crn, planRequest)
@@ -81,7 +82,7 @@ class PlanController(private val planService: PlanService) {
   )
   @GetMapping("/person/{crn}/plans/{planReference}")
   suspend fun getPlan(
-    @PathVariable(value = "crn") @Crn crn: String,
+    @PathVariable(value = "crn") @Crn crn: CaseReferenceNumber,
     @PathVariable(value = "planReference") planReference: UUID,
   ): PlanEntity? {
     return planService.getByKey(PlanKey(crn, planReference))
@@ -108,7 +109,7 @@ class PlanController(private val planService: PlanService) {
   )
   @GetMapping("/person/{crn}/plans")
   suspend fun getAllPlans(
-    @PathVariable(value = "crn") @Crn crn: String,
+    @PathVariable(value = "crn") @Crn crn: CaseReferenceNumber,
   ): Flow<PlanEntity> {
     return planService.findAllByCrn(crn)
   }
@@ -139,7 +140,7 @@ class PlanController(private val planService: PlanService) {
   )
   @DeleteMapping("/person/{crn}/plans/{planReference}")
   suspend fun deletePlan(
-    @PathVariable(value = "crn") @Crn crn: String,
+    @PathVariable(value = "crn") @Crn crn: CaseReferenceNumber,
     @PathVariable(value = "planReference") reference: UUID,
   ): ResponseEntity<Nothing> {
     planService.markPlanDeleted(crn, reference)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import kotlinx.coroutines.flow.Flow
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -181,7 +182,7 @@ class PlanController(private val planService: PlanService) {
   suspend fun addObjectives(
     @PathVariable(value = "crn") @Crn crn: CaseReferenceNumber,
     @PathVariable(value = "planReference") reference: UUID,
-    @RequestBody addObjectiveRequest: AddObjectivesRequest,
+    @RequestBody @Valid addObjectiveRequest: AddObjectivesRequest,
   ): ResponseEntity<Nothing> {
     planService.addObjectives(PlanKey(crn, reference), addObjectiveRequest.objectives)
     return ResponseEntity.noContent().build()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanEntity.kt
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Persistable
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.InsertOnlyProperty
 import org.springframework.data.relational.core.mapping.Table
+import uk.gov.justice.digital.hmpps.hmppsoneplanapi.common.CaseReferenceNumber
 import java.time.ZonedDateTime
 import java.util.UUID
 
@@ -52,4 +53,4 @@ enum class PlanType {
   RESETTLEMENT,
 }
 
-data class PlanKey(val caseReferenceNumber: String, val reference: UUID)
+data class PlanKey(val crn: CaseReferenceNumber, val reference: UUID)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanService.kt
@@ -1,13 +1,28 @@
 package uk.gov.justice.digital.hmpps.hmppsoneplanapi.plan
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toSet
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.common.CaseReferenceNumber
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.exceptions.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsoneplanapi.objective.ObjectiveEntity
+import uk.gov.justice.digital.hmpps.hmppsoneplanapi.objective.ObjectiveRepository
+import uk.gov.justice.digital.hmpps.hmppsoneplanapi.objective.PlanObjectiveLink
 import java.util.UUID
 
 @Service
-class PlanService(private val planRepository: PlanRepository) {
+class PlanService(
+  private val planRepository: PlanRepository,
+  private val objectiveRepository: ObjectiveRepository,
+  private val entityTemplate: R2dbcEntityTemplate,
+) {
   suspend fun getByKey(planKey: PlanKey): PlanEntity {
     val (crn, reference) = planKey
     return planRepository.findByCaseReferenceNumberAndReferenceAndIsDeletedIsFalse(crn.value, reference)
@@ -24,13 +39,38 @@ class PlanService(private val planRepository: PlanRepository) {
     }
   }
 
-  suspend fun createPlan(crn: CaseReferenceNumber, planRequest: CreatePlanRequest): PlanEntity =
-    planRepository.save(
+  @Transactional
+  suspend fun createPlan(crn: CaseReferenceNumber, planRequest: CreatePlanRequest): PlanEntity {
+    val createdPlan = planRepository.save(
       PlanEntity(
         type = planRequest.planType,
         caseReferenceNumber = crn.value,
       ),
     )
+
+    getObjectives(crn, planRequest.objectives).map { objective ->
+      val link = PlanObjectiveLink(planId = createdPlan.id, objectiveId = objective.id)
+      entityTemplate.insert(link).awaitSingle()
+    }.collect()
+
+    return createdPlan
+  }
+
+  suspend fun getObjectives(crn: CaseReferenceNumber, references: Collection<UUID>): Flow<ObjectiveEntity> {
+    if (references.isEmpty()) {
+      return emptyFlow()
+    }
+
+    val foundObjectives = objectiveRepository.getObjectives(crn, references)
+
+    if (foundObjectives.count() != references.size) {
+      val foundRefs = foundObjectives.map { it.reference }.toSet()
+      val firstNotFound = references.first { it !in foundRefs }
+      throw NotFoundException("/person/$crn/objectives/$firstNotFound")
+    }
+
+    return foundObjectives
+  }
 }
 
 fun planNotFound(crn: CaseReferenceNumber, reference: UUID) = NotFoundException("/person/$crn/plans/$reference")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsoneplanapi.plan
 
 import kotlinx.coroutines.flow.Flow
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsoneplanapi.common.CaseReferenceNumber
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.exceptions.NotFoundException
 import java.util.UUID
 
@@ -9,27 +10,27 @@ import java.util.UUID
 class PlanService(private val planRepository: PlanRepository) {
   suspend fun getByKey(planKey: PlanKey): PlanEntity {
     val (crn, reference) = planKey
-    return planRepository.findByCaseReferenceNumberAndReferenceAndIsDeletedIsFalse(crn, reference)
+    return planRepository.findByCaseReferenceNumberAndReferenceAndIsDeletedIsFalse(crn.value, reference)
       ?: throw planNotFound(crn, reference)
   }
 
-  suspend fun findAllByCrn(crn: String): Flow<PlanEntity> =
-    planRepository.findByCaseReferenceNumberAndIsDeletedIsFalse(crn)
+  suspend fun findAllByCrn(crn: CaseReferenceNumber): Flow<PlanEntity> =
+    planRepository.findByCaseReferenceNumberAndIsDeletedIsFalse(crn.value)
 
-  suspend fun markPlanDeleted(crn: String, reference: UUID) {
-    val countUpdated = planRepository.updateMarkDeleted(crn, reference)
+  suspend fun markPlanDeleted(crn: CaseReferenceNumber, reference: UUID) {
+    val countUpdated = planRepository.updateMarkDeleted(crn.value, reference)
     if (countUpdated != 1) {
       throw planNotFound(crn, reference)
     }
   }
 
-  suspend fun createPlan(crn: String, planRequest: CreatePlanRequest): PlanEntity =
+  suspend fun createPlan(crn: CaseReferenceNumber, planRequest: CreatePlanRequest): PlanEntity =
     planRepository.save(
       PlanEntity(
         type = planRequest.planType,
-        caseReferenceNumber = crn,
+        caseReferenceNumber = crn.value,
       ),
     )
 }
 
-fun planNotFound(crn: String, reference: UUID) = NotFoundException("/person/$crn/plans/$reference")
+fun planNotFound(crn: CaseReferenceNumber, reference: UUID) = NotFoundException("/person/$crn/plans/$reference")

--- a/src/main/resources/db/migration/postgres/V1_13__unique-link.sql
+++ b/src/main/resources/db/migration/postgres/V1_13__unique-link.sql
@@ -1,0 +1,1 @@
+create unique index link_plan_id_objective_id ON plan_objective_link(plan_id, objective_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/integration/IntegrationTestBase.kt
@@ -70,12 +70,12 @@ abstract class IntegrationTestBase {
       .returnResult()
       .responseBody!!
       .reference
-    return PlanKey(crn, reference)
+    return PlanKey(CaseReferenceNumber(crn), reference)
   }
 
   fun givenPlanIsDeleted(planKey: PlanKey) {
     authedWebTestClient.delete()
-      .uri("/person/{number}/plans/{ref}", planKey.caseReferenceNumber, planKey.reference)
+      .uri("/person/{number}/plans/{ref}", planKey.crn, planKey.reference)
       .exchange()
       .expectStatus()
       .isNoContent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/integration/IntegrationTestBase.kt
@@ -83,7 +83,6 @@ abstract class IntegrationTestBase {
 
   fun givenAnObjective(
     crn: String = "123",
-    type: PlanType = PlanType.PERSONAL_LEARNING,
     title: String = "title",
     targetCompletionDate: LocalDate = LocalDate.of(2024, 2, 1),
     status: ObjectiveStatus = ObjectiveStatus.IN_PROGRESS,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/objective/ObjectiveControllerTest.kt
@@ -9,7 +9,6 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.common.CaseReferenceNumber
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.common.CreateEntityResponse
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.hmppsoneplanapi.plan.PlanKey
 import java.util.UUID
 
 class ObjectiveControllerTest : IntegrationTestBase() {
@@ -68,7 +67,7 @@ class ObjectiveControllerTest : IntegrationTestBase() {
     authedWebTestClient.post()
       .uri("/person/{crn}/objectives", "123")
       .contentType(MediaType.APPLICATION_JSON)
-      .bodyValue(createObjectiveAndLinkToPlan(PlanKey("123", UUID.randomUUID())))
+      .bodyValue(createObjectiveAndLinkToPlan(UUID.randomUUID()))
       .exchange()
       .expectStatus()
       .isNotFound()
@@ -257,11 +256,11 @@ class ObjectiveControllerTest : IntegrationTestBase() {
   @Test
   fun `GET all objectives for a plan`() {
     val planKey = givenAPlan()
-    val objectiveReferenceA = givenAnObjective(crn = "123", body = createObjectiveAndLinkToPlan(planKey))
-    val objectiveReferenceB = givenAnObjective(crn = "123", body = createObjectiveAndLinkToPlan(planKey))
+    val objectiveReferenceA = givenAnObjective(crn = "123", body = createObjectiveAndLinkToPlan(planKey.reference))
+    val objectiveReferenceB = givenAnObjective(crn = "123", body = createObjectiveAndLinkToPlan(planKey.reference))
 
     authedWebTestClient.get()
-      .uri("/person/{crn}/plans/{pReference}/objectives", planKey.caseReferenceNumber, planKey.reference)
+      .uri("/person/{crn}/plans/{pReference}/objectives", planKey.crn, planKey.reference)
       .exchange()
       .expectStatus()
       .isOk()
@@ -272,14 +271,14 @@ class ObjectiveControllerTest : IntegrationTestBase() {
       }
   }
 
-  private fun createObjectiveAndLinkToPlan(planKey: PlanKey): String = """
+  private fun createObjectiveAndLinkToPlan(planReference: UUID): String = """
             {
                     "title":"title",
                     "targetCompletionDate": "2024-02-01",
                     "status":"IN_PROGRESS",
                     "note":"note",
                     "outcome":"outcome",
-                    "planReference": "${planKey.reference}"
+                    "planReference": "$planReference"
             }
   """.trimIndent()
 
@@ -288,7 +287,7 @@ class ObjectiveControllerTest : IntegrationTestBase() {
     val planKey = givenAPlan()
 
     authedWebTestClient.get()
-      .uri("/person/{crn}/plans/{pReference}/objectives", planKey.caseReferenceNumber, planKey.reference)
+      .uri("/person/{crn}/plans/{pReference}/objectives", planKey.crn, planKey.reference)
       .exchange()
       .expectStatus()
       .isOk()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanControllerValidationTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsoneplanapi/plan/PlanControllerValidationTests.kt
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsoneplanapi.integration.WebfluxTestBase
+import java.util.UUID
 
 @WebFluxTest(controllers = [PlanController::class])
 class PlanControllerValidationTests : WebfluxTestBase() {
@@ -51,6 +52,49 @@ class PlanControllerValidationTests : WebfluxTestBase() {
         assertThat(it.userMessage).isEqualTo("planReference: must be a valid UUID")
       }
   }
+
+  @Test
+  fun `400 when add objective is missing refs`() {
+    val body = "{}"
+    addObjectives(body)
+      .value {
+        assertThat(it.userMessage).isEqualTo("objectives: is required")
+      }
+  }
+
+  @Test
+  fun `400 when add objective has empty refs`() {
+    val body = """{
+        "objectives": []
+      |}
+    """.trimMargin()
+    addObjectives(body)
+      .value {
+        assertThat(it.userMessage).isEqualTo("objectives: must not be empty")
+      }
+  }
+
+  @Test
+  fun `400 when add objective has non UUID refs`() {
+    val body = """{
+        "objectives": [ 123, 456 ]
+      |}
+    """.trimMargin()
+    addObjectives(body)
+      .value {
+        assertThat(it.userMessage).isEqualTo("objectives.[0]: must be a valid UUID")
+      }
+  }
+
+  private fun addObjectives(body: String): WebTestClient.BodySpec<ErrorResponse, *> =
+    authedWebTestClient.patch()
+      .uri("/person/123/plans/{ref}/objectives", UUID.randomUUID())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(body)
+      .exchange()
+      .expectStatus()
+      .isBadRequest()
+      .expectBody(ErrorResponse::class.java)
 
   private fun requestBuilder(type: Any? = "PERSONAL_LEARNING"): String =
     objectMapper.writeValueAsString(


### PR DESCRIPTION
* Add ability to add objectives during create plan
* Add PATCH /plan/{ref}/objectives
* Add index to make sure duplicate objectives are not added (at least referentially)
* Security patch for postgres driver